### PR TITLE
Take a more direct path to dependency caching.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,12 +44,12 @@ ENV PATH      $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 ######################################################################################################################
 
 # Cache any Node.js dependencies with Docker
-ADD package.json /tmp/package.json
-RUN cd /tmp && npm install
-RUN mkdir -p /opt/app && cp -a /tmp/node_modules /opt/app/
+RUN mkdir -p /opt/app
+ADD package.json /opt/app/package.json
+WORKDIR /opt/app
+RUN npm install
 
 # Layer in our application
-WORKDIR /opt/app
 ADD . /opt/app
 
 EXPOSE 3000


### PR DESCRIPTION
No need to do the install at /tmp and copy it over, just install in place.
Also, this was leaving all the npm modules in /tmp adding extra size to the image.